### PR TITLE
シーン遷移アニメーション機能を追加

### DIFF
--- a/project/CG2_01.vcxproj
+++ b/project/CG2_01.vcxproj
@@ -209,6 +209,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="engine\graphic\SkyBox\SkyBoxCommon.cpp" />
     <ClCompile Include="engine\graphic\PSO\SkyBoxPSO.cpp" />
     <ClCompile Include="application\MapChipField.cpp" />
+    <ClCompile Include="SceneChangeAnimation.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="application\Player.h" />
@@ -329,6 +330,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="engine\graphic\Animation\KeyFrame.h" />
     <ClInclude Include="engine\graphic\Animation\Animation.h" />
     <ClInclude Include="engine\math\Quaternion.h" />
+    <ClInclude Include="SceneChangeAnimation.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\imgui\imgui.vcxproj">

--- a/project/CG2_01.vcxproj.filters
+++ b/project/CG2_01.vcxproj.filters
@@ -104,6 +104,7 @@
     <ClCompile Include="engine\graphic\PSO\PostEffect\ToonPSO.cpp" />
     <ClCompile Include="engine\graphic\PSO\PostEffect\BloomPSO.cpp" />
     <ClCompile Include="engine\graphic\PostEffect\BloomEffect.cpp" />
+    <ClCompile Include="SceneChangeAnimation.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="application\BaseCharacter.h" />
@@ -224,6 +225,7 @@
     <ClInclude Include="engine\graphic\PostEffect\BloomEffect.h" />
     <ClInclude Include="application\PlayerBullet.h" />
     <ClInclude Include="application\Player.h" />
+    <ClInclude Include="SceneChangeAnimation.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="CG2.rc" />

--- a/project/SceneChangeAnimation.cpp
+++ b/project/SceneChangeAnimation.cpp
@@ -1,0 +1,180 @@
+#include "SceneChangeAnimation.h"
+#include "ImGuiManager.h"
+#include "TextureManager.h"
+
+SceneChangeAnimation::SceneChangeAnimation(int screenWidth, int screenHeight, int blockSize, float duration, const std::string& blockTexturePath)
+    : m_screenWidth(screenWidth), m_screenHeight(screenHeight), m_blockSize(blockSize), m_duration(duration), m_elapsed(0.0f), m_rng(std::random_device{}()), m_blockTexturePath(blockTexturePath),
+      m_phase(Phase::Appearing) {
+	InitializeBlocks();
+}
+
+void SceneChangeAnimation::Initialize() {
+	m_elapsed = 0.0f;
+	m_phase = Phase::Appearing;
+	InitializeBlocks();
+}
+
+void SceneChangeAnimation::InitializeBlocks() {
+	m_blocks.clear();
+
+	int cols = (m_screenWidth + m_blockSize - 1) / m_blockSize;
+	int rows = (m_screenHeight + m_blockSize - 1) / m_blockSize;
+	float maxIndexSum = static_cast<float>((cols - 1) + (rows - 1));
+
+	for (int y = 0; y < rows; ++y) {
+		for (int x = 0; x < cols; ++x) {
+			Block block;
+			block.x = x * m_blockSize;
+			block.y = y * m_blockSize;
+			block.alpha = 0.0f;
+			float progress = (x + y) / maxIndexSum;
+			float randomOffset = (static_cast<float>(m_rng() % 1000) / 1000.0f) * 0.15f;
+			block.delay = (m_duration * 0.7f) * (progress + randomOffset * (1.0f - progress));
+			block.fading = false;
+			block.sprite = std::make_unique<Sprite>();
+			TextureManager::GetInstance()->LoadTexture(m_blockTexturePath);
+			block.sprite->Initialize(m_blockTexturePath);
+			block.sprite->SetGetIsAdjustTextureSize(false);
+			block.sprite->SetAnchorPoint({0.5f, 0.5f});
+			block.sprite->SetPosition({static_cast<float>(block.x) + m_blockSize * 0.5f, static_cast<float>(block.y) + m_blockSize * 0.5f});
+			block.sprite->SetSize({static_cast<float>(m_blockSize), static_cast<float>(m_blockSize)});
+			
+			// グラデーションカラー（赤→青）
+			float r = 1.0f - progress;
+			float g = 0.0f;
+			float b = progress;
+			block.sprite->SetColor({ r, g, b, 0.0f });
+
+			m_blocks.push_back(std::move(block));
+		}
+	}
+}
+
+void SceneChangeAnimation::Update(float deltaTime) {
+	m_elapsed += deltaTime;
+	bool allAppeared = true;
+	bool allDisappeared = true;
+
+	for (auto& block : m_blocks) {
+		float t = 0.0f;
+		if (m_phase == Phase::Appearing) {
+			if (m_elapsed > block.delay && block.alpha < 1.0f) {
+				// イージングを使って滑らかに
+				t = (m_elapsed - block.delay) / (m_duration * 0.3f);
+				if (t > 1.0f)
+					t = 1.0f;
+				block.alpha = EaseInOut(t);
+				if (block.alpha > 1.0f)
+					block.alpha = 1.0f;
+				auto color = block.sprite->GetColor();
+				color.w = block.alpha;
+				block.sprite->SetColor(color);
+
+				// フェードイン時
+				float appearScale = m_appearScaleMin + (m_appearScaleMax - m_appearScaleMin) * EaseInOut(t);
+				float appearRot = m_appearRotMax * (1.0f - EaseInOut(t));
+				block.sprite->SetSize({m_blockSize * appearScale, m_blockSize * appearScale});
+				block.sprite->SetRotation(appearRot);
+			}
+			if (block.alpha < 1.0f)
+				allAppeared = false;
+		} else if (m_phase == Phase::Disappearing) {
+			if (m_elapsed > block.delay && block.alpha > 0.0f) {
+				t = (m_elapsed - block.delay) / (m_duration * 0.3f);
+				if (t > 1.0f)
+					t = 1.0f;
+				block.alpha = 1.0f - EaseInOut(t);
+				if (block.alpha < 0.0f)
+					block.alpha = 0.0f;
+				auto color = block.sprite->GetColor();
+				color.w = block.alpha;
+				block.sprite->SetColor(color);
+
+				// フェードアウト時
+				float disappearScale = m_disappearScaleMax - (m_disappearScaleMax - m_disappearScaleMin) * EaseInOut(t);
+				float disappearRot = m_disappearRotMax * EaseInOut(t);
+				block.sprite->SetSize({m_blockSize * disappearScale, m_blockSize * disappearScale});
+				block.sprite->SetRotation(disappearRot);
+			}
+			if (block.alpha > 0.0f)
+				allDisappeared = false;
+		}
+		block.sprite->Update();
+	}
+
+	if (m_phase == Phase::Appearing && allAppeared) {
+		m_phase = Phase::Disappearing;
+		m_elapsed = 0.0f;
+	} else if (m_phase == Phase::Disappearing && allDisappeared) {
+		m_phase = Phase::Finished;
+	}
+}
+
+// S字イージング関数
+float SceneChangeAnimation::EaseInOut(float t) { return t < 0.5f ? 2.0f * t * t : 1.0f - powf(-2.0f * t + 2.0f, 2.0f) / 2.0f; }
+
+void SceneChangeAnimation::Draw() const {
+	for (const auto& block : m_blocks) {
+		if (block.alpha > 0.0f) {
+			block.sprite->Draw();
+		}
+	}
+}
+
+bool SceneChangeAnimation::IsFinished() const { return m_phase == Phase::Finished; }
+
+// ImGuiコントロール
+void SceneChangeAnimation::DrawImGui() {
+	ImGui::Begin("SceneChangeAnimation");
+
+	static int blockSize = m_blockSize;
+	static float duration = m_duration;
+	static char texturePath[128];
+	
+
+	strcpy_s(texturePath, sizeof(texturePath), m_blockTexturePath.c_str());
+
+	bool needReinit = false;
+
+	if (ImGui::InputInt("Block Size", &blockSize))
+		needReinit = true;
+	if (ImGui::InputFloat("Duration", &duration))
+		needReinit = true;
+	if (ImGui::InputText("Texture", texturePath, sizeof(texturePath)))
+		needReinit = true;
+
+	ImGui::Separator();
+	ImGui::Text("Appear Animation");
+	if (ImGui::SliderFloat("Appear Scale Min", &m_appearScaleMin, 0.1f, 1.0f)) {
+	}
+	if (ImGui::SliderFloat("Appear Scale Max", &m_appearScaleMax, 0.1f, 2.0f)) {
+	}
+	if (ImGui::SliderFloat("Appear Rot Max", &m_appearRotMax, 0.0f, 2.0f)) {
+	}
+
+	ImGui::Text("Disappear Animation");
+
+
+	if (ImGui::SliderFloat("Disappear Scale Min", &m_disappearScaleMin, 0.1f, 1.0f)) {
+	}
+	if (ImGui::SliderFloat("Disappear Scale Max", &m_disappearScaleMax, 0.1f, 2.0f)) {
+	}
+	if (ImGui::SliderFloat("Disappear Rot Max", &m_disappearRotMax, 0.0f, 2.0f)) {
+	}
+
+	if (ImGui::Button("Reinitialize"))
+		needReinit = true;
+
+	if (needReinit) {
+		m_blockSize = blockSize;
+		m_duration = duration;
+		m_blockTexturePath = texturePath;
+		// ここで拡大率・回転量のパラメータもメンバ変数に保存する場合はセット
+		Initialize();
+	}
+
+	ImGui::Text("Phase: %s", m_phase == Phase::Appearing ? "Appearing" : m_phase == Phase::Disappearing ? "Disappearing" : "Finished");
+	ImGui::Text("IsFinished: %s", IsFinished() ? "Yes" : "No");
+
+	ImGui::End();
+}

--- a/project/SceneChangeAnimation.h
+++ b/project/SceneChangeAnimation.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <vector>
+#include <random>
+#include <memory>
+#include "engine/graphic/2d/Sprite.h"
+
+class SceneChangeAnimation {
+public:
+    SceneChangeAnimation(int screenWidth, int screenHeight, int blockSize, float duration, const std::string& blockTexturePath);
+
+    void Initialize();
+    void Update(float deltaTime);
+    void Draw() const;
+    bool IsFinished() const;
+	static float EaseInOut(float t);
+	void DrawImGui();
+
+private:
+    struct Block {
+        int x, y;
+        float alpha;
+        float delay;
+        bool fading;
+        std::unique_ptr<Sprite> sprite;
+    };
+    
+    enum class Phase { Appearing, Disappearing, Finished };
+
+    int m_screenWidth;
+    int m_screenHeight;
+    int m_blockSize;
+    float m_duration;
+    float m_elapsed;
+    std::vector<Block> m_blocks;
+    std::mt19937 m_rng;
+    std::string m_blockTexturePath;
+	
+	Phase m_phase;
+
+	float m_appearScaleMin = 0.1f;
+	float m_appearScaleMax = 1.0f;
+	float m_appearRotMax = 2.0f;
+	float m_disappearScaleMin = 0.1f;
+	float m_disappearScaleMax = 1.0f;
+	float m_disappearRotMax = 2.0f;
+
+    void InitializeBlocks();
+};

--- a/project/engine/graphic/2d/Sprite.cpp
+++ b/project/engine/graphic/2d/Sprite.cpp
@@ -114,7 +114,7 @@ void Sprite::Initialize(std::string textureFilePath)
 
 	textureIndex = TextureManager::GetInstance()->GetSrvIndex(textureFilePath);
 
-
+	AdjustTextureSize();
 }
 
 void Sprite::Update()
@@ -160,10 +160,6 @@ void Sprite::Update()
 	//テクスチャの初期サイズを呼び出す関数
 	if (isAdjustTextureSize) {
 		AdjustTextureSize();
-	}
-	else {
-		textureSize_ = { 100.0f,100.0f };
-		size = textureSize_;
 	}
 
 	/*---------------------------------------

--- a/project/engine/scene/DebugScene.cpp
+++ b/project/engine/scene/DebugScene.cpp
@@ -112,6 +112,12 @@ void DebugScene::Initialize() {
 #pragma endregion cameraの初期化
 
 
+	//シーンチェンジアニメーション
+	sceneChangeAnimation = std::make_unique<SceneChangeAnimation>(1280, 720, 80, 1.5f, "barrier.png");
+	sceneChangeAnimation->Initialize();
+	showSceneChangeAnimation = false;
+
+
 }
 
 void DebugScene::Update() {
@@ -145,7 +151,7 @@ void DebugScene::Update() {
 	skyBox->SetCamera(camera.get());
 	skyBox->Update();
 
-
+	sceneChangeAnimation->Update(1.0f / 60.0f);
 
 }
 
@@ -174,11 +180,31 @@ void DebugScene::SpriteDraw() {
 		}
 	}
 	
+	if (showSceneChangeAnimation) {
+		sceneChangeAnimation->Draw();
+		if (sceneChangeAnimation->IsFinished()) {
+			showSceneChangeAnimation = false;
+		}
+	}
+	
 }
 
 void DebugScene::ImGuiDraw() {
 	ImGui::Begin("DebugScene");
 	ImGui::Text("Hello, DebugScene!");
+
+	// シーンチェンジアニメーション ImGui
+	if (ImGui::Button("Start SceneChangeAnimation")) {
+		if (sceneChangeAnimation) {
+			sceneChangeAnimation->Initialize();
+			showSceneChangeAnimation = true;
+		}
+	}
+	ImGui::Checkbox("Show SceneChangeAnimation", &showSceneChangeAnimation);
+	if (sceneChangeAnimation) {
+		ImGui::Text("Animation Finished: %s", sceneChangeAnimation->IsFinished() ? "Yes" : "No");
+	}
+
 	ImGui::End();
 
 	//skyBoxのImGui
@@ -265,6 +291,7 @@ void DebugScene::ImGuiDraw() {
 	
 	#endif // DEBUG
 
+		sceneChangeAnimation->DrawImGui();
 }
 
 void DebugScene::ParticleDraw() {

--- a/project/engine/scene/DebugScene.h
+++ b/project/engine/scene/DebugScene.h
@@ -21,6 +21,7 @@
 #include"ImGuiManager.h"
 
 #include"SkyBox.h"
+#include"SceneChangeAnimation.h"
 
 
 #undef min//minマクロを無効化
@@ -125,6 +126,12 @@ private:
 	///SkyBox
 	
 	std::unique_ptr<SkyBox> skyBox = nullptr;
+
+	/// SceneChangeAnimation
+	std::unique_ptr<SceneChangeAnimation> sceneChangeAnimation = nullptr;
+	bool isSceneChange = false;
+	float sceneChangeTimer = 0.0f;
+	bool showSceneChangeAnimation = false;
 	
 };
 

--- a/project/engine/scene/SceneManager.cpp
+++ b/project/engine/scene/SceneManager.cpp
@@ -17,7 +17,7 @@ void SceneManager::Initialize() {
 	currentSceneNo = 0;
 	//前のシーン番号を設定
 	prevSceneNo = -1;
-}
+}	
 
 void SceneManager::Update() {
 	//現在のシーンがnullptrでない場合

--- a/project/imgui.ini
+++ b/project/imgui.ini
@@ -44,13 +44,13 @@ Size=310,223
 Collapsed=1
 
 [Window][Scene]
-Pos=254,101
+Pos=171,20
 Size=84,147
-Collapsed=0
+Collapsed=1
 
 [Window][DebugScene]
-Pos=26,3
-Size=147,60
+Pos=572,246
+Size=369,177
 Collapsed=0
 
 [Window][BlenderMode]
@@ -109,7 +109,7 @@ Size=277,121
 Collapsed=0
 
 [Window][PostEffect]
-Pos=11,277
+Pos=22,14
 Size=295,57
 Collapsed=0
 
@@ -125,7 +125,7 @@ Collapsed=0
 
 [Window][Dissolve Effect]
 Pos=62,64
-Size=462,118
+Size=462,121
 Collapsed=0
 
 [Window][SkyBox]
@@ -161,7 +161,7 @@ Collapsed=1
 [Window][plane]
 Pos=860,197
 Size=410,533
-Collapsed=0
+Collapsed=1
 
 [Window][terran]
 Pos=461,202
@@ -241,5 +241,10 @@ Collapsed=0
 [Window][Grid Settings]
 Pos=470,81
 Size=131,54
+Collapsed=0
+
+[Window][SceneChangeAnimation]
+Pos=40,78
+Size=387,363
 Collapsed=0
 


### PR DESCRIPTION
`SceneChangeAnimation` クラスを新規追加し、シーン遷移アニメーションを実装しました。このクラスは、画面をブロック単位で分割し、ブロックがフェードイン・フェードアウトするアニメーションを提供します。

- `SceneChangeAnimation.h` と `SceneChangeAnimation.cpp` を追加。
  - アニメーションの初期化 (`Initialize`)、更新 (`Update`)、描画 (`Draw`) を実装。
  - ImGui を使用したデバッグ用 UI (`DrawImGui`) を提供。
  - イージング関数 `EaseInOut` を使用して滑らかなアニメーションを実現。
- `DebugScene` クラスに `SceneChangeAnimation` を統合。
  - 初期化、更新、描画、ImGui デバッグ UI を追加。
- プロジェクトファイル (`CG2_01.vcxproj` と `CG2_01.vcxproj.filters`) に新しいファイルを登録。
- `Sprite` クラスのテクスチャサイズ初期化処理を調整。
- `imgui.ini` に新しいウィンドウ設定 `[SceneChangeAnimation]` を追加。