### PR TITLE
シーン遷移アニメーションの改善とコードリファクタリング

### DIFF
--- a/project/SceneChangeAnimation.h
+++ b/project/SceneChangeAnimation.h
@@ -1,40 +1,45 @@
 #pragma once
-#include <vector>
-#include <random>
-#include <memory>
 #include "engine/graphic/2d/Sprite.h"
+#include <memory>
+#include <random>
+#include <vector>
 
 class SceneChangeAnimation {
-public:
-    SceneChangeAnimation(int screenWidth, int screenHeight, int blockSize, float duration, const std::string& blockTexturePath);
 
-    void Initialize();
-    void Update(float deltaTime);
-    void Draw() const;
-    bool IsFinished() const;
+public:
+	enum class Phase { Appearing, Disappearing, Finished };
+
+	SceneChangeAnimation(int screenWidth, int screenHeight, int blockSize, float duration, const std::string& blockTexturePath);
+
+	void Initialize();
+	void Update(float deltaTime);
+	void Draw() const;
+	bool IsFinished() const;
 	static float EaseInOut(float t);
 	void DrawImGui();
 
-private:
-    struct Block {
-        int x, y;
-        float alpha;
-        float delay;
-        bool fading;
-        std::unique_ptr<Sprite> sprite;
-    };
-    
-    enum class Phase { Appearing, Disappearing, Finished };
+public:
+	Phase GetPhase() const { return m_phase; }
+	void SetPhase(Phase phase);
 
-    int m_screenWidth;
-    int m_screenHeight;
-    int m_blockSize;
-    float m_duration;
-    float m_elapsed;
-    std::vector<Block> m_blocks;
-    std::mt19937 m_rng;
-    std::string m_blockTexturePath;
-	
+private:
+	struct Block {
+		int x, y;
+		float alpha;
+		float delay;
+		bool fading;
+		std::unique_ptr<Sprite> sprite;
+	};
+
+	int m_screenWidth;
+	int m_screenHeight;
+	int m_blockSize;
+	float m_duration;
+	float m_elapsed;
+	std::vector<Block> m_blocks;
+	std::mt19937 m_rng;
+	std::string m_blockTexturePath;
+
 	Phase m_phase;
 
 	float m_appearScaleMin = 0.1f;
@@ -44,5 +49,7 @@ private:
 	float m_disappearScaleMax = 1.0f;
 	float m_disappearRotMax = 2.0f;
 
-    void InitializeBlocks();
+	void InitializeBlocks();
+	void UpdateAppearing(float deltaTime);
+	void UpdateDisappearing(float deltaTime);
 };

--- a/project/engine/scene/DebugScene.cpp
+++ b/project/engine/scene/DebugScene.cpp
@@ -1,27 +1,24 @@
 #include "DebugScene.h"
-#include"ImGuiManager.h"
-#include"SceneManager.h"
-#include"ModelManager.h"
-#include"TextureManager.h"
-#include"BlendMode.h"
+#include "BlendMode.h"
+#include "ImGuiManager.h"
+#include "ModelManager.h"
+#include "SceneManager.h"
+#include "TextureManager.h"
 void DebugScene::Initialize() {
 
-	//テクスチャマネージャに追加する画像ハンドル
+	// テクスチャマネージャに追加する画像ハンドル
 	std::string uvCheckerTextureHandle = "uvChecker.png";
 	std::string monsterBallTextureHandle = "monsterBall.png";
 
 	std::string testDDSTextureHandle = "rostock_laage_airport_4k.dds";
 
-	//モデルファイルパス
+	// モデルファイルパス
 	const std::string modelFileNamePath = "sphere.gltf";
-	//モデルファイルパス2
+	// モデルファイルパス2
 	const std::string modelFileNamePath2 = "terrain.obj";
 
-
-	//オーディオ
+	// オーディオ
 	const std::string audioFileName = "fanfare.wav";
-	
-
 
 #pragma region Audioの初期化
 	audio = std::make_unique<Audio>();
@@ -29,99 +26,29 @@ void DebugScene::Initialize() {
 	audio->Play(false);
 
 #pragma endregion Audioの初期化
-	/*---------------
-		スプライト
-	---------------*/
-#pragma region スプライトの初期化
-	// スプライト初期化
-
-	for (uint32_t i = 0; i < 1; ++i) {
-
-		Sprite* sprite = new Sprite();
-
-		//もしfor文のiが偶数なら
-		if (i % 2 == 0) {
-			//モンスターボールを表示させる
-			sprite->Initialize( monsterBallTextureHandle);
-		} else {
-			//uvCheckerを表示させる
-			sprite->Initialize( uvCheckerTextureHandle);
-		}
-
-
-		// 各スプライトに異なる位置やプロパティを設定する
-		//Vector2 spritePosition = { i * -1280.0f, 0.0f }; // スプライトごとに異なる位置
-		Vector2 spritePosition = { 100.0f, 100.0f }; // スプライトごとに異なる位置
-		float spriteRotation = 0.0f;                 // 回転は任意
-		Vector4 spriteColor = { 1.0f, 1.0f, 1.0f, 1.0f }; // 色は白（RGBA）
-		Vector2 size = { 50.0f, 50.0f };             // 任意のサイズ
-
-		
-		//スプライトの位置や回転を設定
-		sprite->SetPosition(spritePosition);
-		sprite->SetRotation(spriteRotation);
-		sprite->SetColor(spriteColor);
-		sprite->SetSize(size);
-		
-		sprites.push_back(sprite);
-
-	}
-#pragma endregion スプライトの初期化
 
 
 	skyBox = std::make_unique<SkyBox>();
 	skyBox->Initialize(testDDSTextureHandle);
 
-
-	/*---------------
-	  オブジェクト3D
-	---------------*/
-#pragma region 3Dモデルの初期化
-	//オブジェクト3D
-
-	object3d = std::make_unique<Object3d>();
-	object3d->Initialize(modelFileNamePath);
-
-	object3d->SetModel(modelFileNamePath);
-	object3d->SetCubeMapFilePath(skyBox->GetTextureFilePath());
-
-
-	////////////////////////////////////////////////////////////////////////
-
-
-
-	//オブジェクト3D
-
-	object3d2 = std::make_unique<Object3d>();
-	object3d2->Initialize(modelFileNamePath2);
 	
 
-#pragma endregion 3Dモデルの初期化
-
 #pragma region cameraの初期化
-	//カメラ
+	// カメラ
 
 	camera = std::make_unique<Camera>();
 	camera->SetTranslate(cameraPosition);
 	camera->setRotation(cameraRotation);
 	camera->setScale(cameraScale);
 
-	object3d->SetCamera(camera.get());
-	object3d2->SetCamera(camera.get());
-
 #pragma endregion cameraの初期化
 
-
-	//シーンチェンジアニメーション
+	// シーンチェンジアニメーション
 	sceneChangeAnimation = std::make_unique<SceneChangeAnimation>(1280, 720, 80, 1.5f, "barrier.png");
-	sceneChangeAnimation->Initialize();
-	showSceneChangeAnimation = false;
-
-
+	sceneChangeAnimation->Initialize(); 
 }
 
 void DebugScene::Update() {
-	
 
 	// --- 既存のカメラ・オブジェクト・スプライト更新処理 ---
 	camera->SetTranslate(cameraPosition);
@@ -129,85 +56,51 @@ void DebugScene::Update() {
 	camera->setScale(cameraScale);
 	camera->Update();
 
-	object3d->Update();
-	object3d->SetPosition(modelPosition);
-	object3d->SetRotation(modelRotation);
-	object3d->SetScale(modelScale);
-
-	object3d2->Update();
-	object3d2->SetPosition(modelPosition2);
-	object3d2->SetRotation(modelRotation2);
-	object3d2->SetScale(modelScale2);
-	
-	//スプライトの更新
-	for (Sprite* sprite : sprites) {
-		if (sprite) {
-			
-			sprite->Update();
-		}
-	}
-
 
 	skyBox->SetCamera(camera.get());
 	skyBox->Update();
 
+	// スペースキーで覆いを出すリクエスト
+	if (Input::GetInstance()->TriggerKey(DIK_SPACE)) {
+		
+		sceneChangeAnimation->SetPhase(SceneChangeAnimation::Phase::Appearing); // 覆いを出す
+		isRequestSceneChange = true; // シーン遷移リクエスト
+	}
+
 	sceneChangeAnimation->Update(1.0f / 60.0f);
 
+	// アニメーションが終わったらシーン遷移
+	if (isRequestSceneChange && sceneChangeAnimation->IsFinished()) {
+		// ここでシーン遷移処理を呼ぶ
+		SceneManager::GetInstance()->ChangeScene(SCENE::TITLE);
+		isRequestSceneChange = false; // フラグリセット
+	}
 }
 
 void DebugScene::Finalize() {
 
-	for (Sprite* sprite : sprites) {
-		if (sprite) {
-			delete sprite; // メモリを解放
-		}
-	}
-	sprites.clear(); // ポインタをクリア
-
 }
 
 void DebugScene::Object3DDraw() {
-	object3d->Draw();
-	object3d2->Draw();
-
+	
 	skyBox->Draw();
 }
 
 void DebugScene::SpriteDraw() {
-	for (Sprite* sprite : sprites) {
-		if (sprite) {
-			sprite->Draw();
-		}
-	}
 	
-	if (showSceneChangeAnimation) {
-		sceneChangeAnimation->Draw();
-		if (sceneChangeAnimation->IsFinished()) {
-			showSceneChangeAnimation = false;
-		}
-	}
-	
+
+	// アニメーション描画
+
+	sceneChangeAnimation->Draw();
 }
 
 void DebugScene::ImGuiDraw() {
 	ImGui::Begin("DebugScene");
 	ImGui::Text("Hello, DebugScene!");
 
-	// シーンチェンジアニメーション ImGui
-	if (ImGui::Button("Start SceneChangeAnimation")) {
-		if (sceneChangeAnimation) {
-			sceneChangeAnimation->Initialize();
-			showSceneChangeAnimation = true;
-		}
-	}
-	ImGui::Checkbox("Show SceneChangeAnimation", &showSceneChangeAnimation);
-	if (sceneChangeAnimation) {
-		ImGui::Text("Animation Finished: %s", sceneChangeAnimation->IsFinished() ? "Yes" : "No");
-	}
-
 	ImGui::End();
 
-	//skyBoxのImGui
+	// skyBoxのImGui
 
 	static Vector3 skyBoxPosition = skyBox->GetTransform().translate;
 	static Vector3 skyBoxRotation = skyBox->GetTransform().rotate;
@@ -219,81 +112,68 @@ void DebugScene::ImGuiDraw() {
 	ImGui::DragFloat3("Scale", &skyBoxScale.x, 0.1f);
 	ImGui::End();
 
+#ifdef _DEBUG
+
+	ImGui::Begin("camera");
+	ImGui::DragFloat3("Position", &cameraPosition.x, 0.1f);
+	ImGui::DragFloat3("Rotation", &cameraRotation.x, 0.1f);
+	ImGui::DragFloat3("Scale", &cameraScale.x, 0.1f);
+	Matrix4x4 projectionInverse = Inverse(camera->GetProjectionMatrix());
+	ImGui::Text("Projection Inverse:");
+	ImGui::Text("m[0][0]: %f", projectionInverse.m[0][0]);
+	ImGui::Text("m[1][1]: %f", projectionInverse.m[1][1]);
+	ImGui::Text("m[2][2]: %f", projectionInverse.m[2][2]);
+	ImGui::Text("m[3][3]: %f", projectionInverse.m[3][3]);
+	ImGui::Text("m[0][1]: %f", projectionInverse.m[0][1]);
+	ImGui::Text("m[1][0]: %f", projectionInverse.m[1][0]);
+
+	ImGui::End();
 
 	
-	#ifdef _DEBUG
-	
-		ImGui::Begin("camera");
-		ImGui::DragFloat3("Position", &cameraPosition.x, 0.1f);
-		ImGui::DragFloat3("Rotation", &cameraRotation.x, 0.1f);
-		ImGui::DragFloat3("Scale", &cameraScale.x, 0.1f);
-	    Matrix4x4 projectionInverse = Inverse(camera->GetProjectionMatrix());
-	    ImGui::Text("Projection Inverse:");
-	    ImGui::Text("m[0][0]: %f", projectionInverse.m[0][0]);
-	    ImGui::Text("m[1][1]: %f", projectionInverse.m[1][1]);
-	    ImGui::Text("m[2][2]: %f", projectionInverse.m[2][2]);
-	    ImGui::Text("m[3][3]: %f", projectionInverse.m[3][3]);
-	    ImGui::Text("m[0][1]: %f", projectionInverse.m[0][1]);
-	    ImGui::Text("m[1][0]: %f", projectionInverse.m[1][0]);
 
-		ImGui::End();
-	
-		//スプライトのImGui
-		for (Sprite* sprite : sprites) {
-			if (sprite) {
-				sprite->DrawImGui("sprite");
-			}
-		}
+	static float scratchPosition = 0.0f;
+	static bool isScratching = false;
+	static float lastScratchPosition = 0.0f;
+	// 再生時間
+	float duration = audio->GetSoundDuration();
 
-		object3d->DrawImGui("plane");
-		object3d2->DrawImGui("terran");
+	ImGui::Begin("Audio Control");
 
-		static float scratchPosition = 0.0f;
-		static bool isScratching = false;
-		static float lastScratchPosition = 0.0f;
-		//再生時間
-		float duration = audio->GetSoundDuration();
-	
-		ImGui::Begin("Audio Control");
-	
-		if (ImGui::Button("Play")) {
-			audio->Play(false);
-		}
-		if (ImGui::Button("Stop")) {
-			audio->Stop();
-		}
-		if (ImGui::Button("Pause")) {
-			audio->Pause();
-		}
-		if (ImGui::Button("Resume")) {
-			audio->Resume();
-		}
-		//volume
-		static float volume = 0.1f;
-		ImGui::SliderFloat("Volume", &volume, 0.0f, 1.0f);
-		audio->SetVolume(volume);
-	
-		// 再生バー
-		static float playbackPosition = 0.0f;
-		//再生位置の取得
-		playbackPosition = audio->GetPlaybackPosition();
-		//再生位置の視認
-		ImGui::SliderFloat("Playback Position", &playbackPosition, 0.0f, duration);
-		//audio->SetPlaybackPosition(playbackPosition);
-	
-		//speed
-		static float speed = 1.0f;
-		ImGui::SliderFloat("Speed", &speed, 0.0f, 2.0f);
-		audio->SetPlaybackSpeed(speed);
-	
-		ImGui::End();
-	
-	
-	#endif // DEBUG
+	if (ImGui::Button("Play")) {
+		audio->Play(false);
+	}
+	if (ImGui::Button("Stop")) {
+		audio->Stop();
+	}
+	if (ImGui::Button("Pause")) {
+		audio->Pause();
+	}
+	if (ImGui::Button("Resume")) {
+		audio->Resume();
+	}
+	// volume
+	static float volume = 0.1f;
+	ImGui::SliderFloat("Volume", &volume, 0.0f, 1.0f);
+	audio->SetVolume(volume);
 
-		sceneChangeAnimation->DrawImGui();
+	// 再生バー
+	static float playbackPosition = 0.0f;
+	// 再生位置の取得
+	playbackPosition = audio->GetPlaybackPosition();
+	// 再生位置の視認
+	ImGui::SliderFloat("Playback Position", &playbackPosition, 0.0f, duration);
+	// audio->SetPlaybackPosition(playbackPosition);
+
+	// speed
+	static float speed = 1.0f;
+	ImGui::SliderFloat("Speed", &speed, 0.0f, 2.0f);
+	audio->SetPlaybackSpeed(speed);
+
+	ImGui::End();
+
+#endif // DEBUG
+
+	sceneChangeAnimation->DrawImGui();
 }
 
-void DebugScene::ParticleDraw() {
-
-}
+void DebugScene::ParticleDraw() {}

--- a/project/engine/scene/DebugScene.h
+++ b/project/engine/scene/DebugScene.h
@@ -83,26 +83,7 @@ private:
 	///Audio///
 	std::unique_ptr<Audio> audio = nullptr;
 	
-	///Sprite///
-
 	
-	std::vector<Sprite*> sprites;
-
-	///Model///
-
-	std::unique_ptr<Object3d> object3d;
-	Vector3 modelPosition = { 0.0f,0.0f,0.0f };
-	Vector3 modelRotation = { 0.0f,0.0f,0.0f };
-	Vector3 modelScale = { 1.0f,1.0f,1.0f };
-
-
-
-	std::unique_ptr <Object3d> object3d2;
-	Vector3 modelPosition2 = { 0.0f,0.0f,0.0f };
-	Vector3 modelRotation2 = { 0.0f,0.0f,0.0f };
-	Vector3 modelScale2 = { 1.0f,1.0f,1.0f };
-
-
 	//Camera///
 
 	std::unique_ptr <Camera> camera = nullptr;
@@ -129,9 +110,6 @@ private:
 
 	/// SceneChangeAnimation
 	std::unique_ptr<SceneChangeAnimation> sceneChangeAnimation = nullptr;
-	bool isSceneChange = false;
-	float sceneChangeTimer = 0.0f;
-	bool showSceneChangeAnimation = false;
-	
+	bool isRequestSceneChange = false;
 };
 

--- a/project/engine/scene/TitleScene.h
+++ b/project/engine/scene/TitleScene.h
@@ -5,12 +5,14 @@
 #include "Particle.h"
 #include "ParticleEmitter.h"
 #include <random>
+#include "SceneChangeAnimation.h"
+
 class TitleScene : public IScene {
 public:
 	/// <summary>
 	/// 初期化
 	/// </summary>
-	void Initialize();
+	void Initialize() override;
 
 	/// <summary>
 	/// 更新
@@ -61,4 +63,8 @@ private:
 	Vector3 cameraPosition = {0.0f, 0.0f, -5.0f};
 	Vector3 cameraRotation = {0.0f, 0.0f, 0.0f};
 	Vector3 cameraScale = {1.0f, 1.0f, 1.0f};
+
+	// --- ここを追加 ---
+	std::unique_ptr<SceneChangeAnimation> sceneChangeAnimation;
+	bool isRequestSceneChange = false;
 };

--- a/project/imgui.ini
+++ b/project/imgui.ini
@@ -46,7 +46,7 @@ Collapsed=1
 [Window][Scene]
 Pos=171,20
 Size=84,147
-Collapsed=1
+Collapsed=0
 
 [Window][DebugScene]
 Pos=572,246
@@ -109,7 +109,7 @@ Size=277,121
 Collapsed=0
 
 [Window][PostEffect]
-Pos=22,14
+Pos=566,97
 Size=295,57
 Collapsed=0
 
@@ -244,7 +244,7 @@ Size=131,54
 Collapsed=0
 
 [Window][SceneChangeAnimation]
-Pos=40,78
+Pos=39,241
 Size=387,363
 Collapsed=0
 


### PR DESCRIPTION
`SceneChangeAnimation`のフェーズ管理を改善し、`Appearing`と`Disappearing`の処理を専用メソッドに分割。`SetPhase`メソッドを追加し、外部からフェーズを設定可能に。`DebugScene`と`TitleScene`にシーン遷移アニメーションを統合し、スペースキーでの遷移リクエストやアニメーション終了後のシーン切り替えを実装。`ImGui`でのデバッグ情報表示を整理し、ウィンドウ位置やサイズを調整。不要なコードやコメントを削除し、全体的な可読性を向上。