### PR TITLE
テキスト揃え（アンカー）機能の追加

### DIFF
--- a/project/Resources/Text/layout.json
+++ b/project/Resources/Text/layout.json
@@ -9,13 +9,15 @@
       ],
       "font": "Best10",
       "fontSize": 32.0,
+      "horizontalAlign": 0,
       "name": "Text",
       "position": [
         100.0,
         100.0
       ],
       "scale": 1.0,
-      "text": "茄子はおいしいよ"
+      "text": "茄子はおいしいよ",
+      "verticalAlign": 0
     }
   ]
 }

--- a/project/engine/graphic/2d/TextManager.cpp
+++ b/project/engine/graphic/2d/TextManager.cpp
@@ -18,20 +18,20 @@ TextManager* TextManager::instance_ = nullptr;
 // シングルトンインスタンス取得
 // 初回呼び出し時に動的確保し、その後は同じインスタンスを返す。
 TextManager* TextManager::GetInstance() {
-	if (instance_ == nullptr) {
-		instance_ = new TextManager();
-	}
-	return instance_;
+    if (instance_ == nullptr) {
+        instance_ = new TextManager();
+    }
+    return instance_;
 }
 
 // シングルトンインスタンス破棄
 // Finalize() を呼び出してリソースを解放した後、インスタンスを delete する。
 void TextManager::DestroyInstance() {
-	if (instance_) {
-		instance_->Finalize();
-		delete instance_;
-		instance_ = nullptr;
-	}
+    if (instance_) {
+        instance_->Finalize();
+        delete instance_;
+        instance_ = nullptr;
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -44,30 +44,30 @@ void TextManager::DestroyInstance() {
 // - BaseFont 名リストの構築
 void TextManager::Initialize() {
 #ifdef _WIN32
-	windowsFontDir_ = "C:/Windows/Fonts/";
+    windowsFontDir_ = "C:/Windows/Fonts/";
 #endif
 
-	// プリセット BaseFont 登録
-	LoadFontFromExternal(PresetFontNames::Best10, "BestTen-CRT.otf", 32.0f);
-	LoadFontFromExternal(PresetFontNames::SoukouMincho, "SoukouMincho.ttf", 32.0f);
-	LoadFontFromExternal(PresetFontNames::UtsukushiFONT, "UtsukushiFONT.otf", 24.0f);
-	LoadFontFromExternal(PresetFontNames::YasashisaGothicBold, "YasashisaGothicBold-V2.otf", 48.0f);
+    // プリセット BaseFont 登録
+    LoadFontFromExternal(PresetFontNames::Best10, "BestTen-CRT.otf", 32.0f);
+    LoadFontFromExternal(PresetFontNames::SoukouMincho, "SoukouMincho.ttf", 32.0f);
+    LoadFontFromExternal(PresetFontNames::UtsukushiFONT, "UtsukushiFONT.otf", 24.0f);
+    LoadFontFromExternal(PresetFontNames::YasashisaGothicBold, "YasashisaGothicBold-V2.otf", 48.0f);
 
-	baseFontNames_.push_back(PresetFontNames::Best10);
-	baseFontNames_.push_back(PresetFontNames::SoukouMincho);
-	baseFontNames_.push_back(PresetFontNames::UtsukushiFONT);
-	baseFontNames_.push_back(PresetFontNames::YasashisaGothicBold);
+    baseFontNames_.push_back(PresetFontNames::Best10);
+    baseFontNames_.push_back(PresetFontNames::SoukouMincho);
+    baseFontNames_.push_back(PresetFontNames::UtsukushiFONT);
+    baseFontNames_.push_back(PresetFontNames::YasashisaGothicBold);
 }
 
 // TextManager が保持しているフォント／テキスト関連のリソースを全て解放する。
 // シングルトン破棄前やシーン終了時などに呼び出す想定。
 void TextManager::Finalize() {
-	fonts_.clear();
-	texts_.clear();
-	textDefs_.clear();
-	baseFontNames_.clear();
-	addedFontNames_.clear();
-	sizedFontNames_.clear();
+    fonts_.clear();
+    texts_.clear();
+    textDefs_.clear();
+    baseFontNames_.clear();
+    addedFontNames_.clear();
+    sizedFontNames_.clear();
 }
 
 //----------------------------------------------------------------------------
@@ -78,30 +78,30 @@ void TextManager::Finalize() {
 // ・textAlive_ が false のものは Update をスキップし、ループ後にまとめて erase する。
 // ・後ろから erase することでインデックスずれを防いでいる。
 void TextManager::UpdateAll() {
-	for (size_t i = 0; i < texts_.size(); ++i) {
-		if (i < textAlive_.size() && !textAlive_[i])
-			continue;
-		texts_[i]->Update();
-	}
+    for (size_t i = 0; i < texts_.size(); ++i) {
+        if (i < textAlive_.size() && !textAlive_[i])
+            continue;
+        texts_[i]->Update();
+    }
 
-	// ここでフラグが false のものを後ろから erase
-	for (size_t i = texts_.size(); i-- > 0;) {
-		if (i < textAlive_.size() && !textAlive_[i]) {
-			texts_.erase(texts_.begin() + static_cast<std::ptrdiff_t>(i));
-			textDefs_.erase(textDefs_.begin() + static_cast<std::ptrdiff_t>(i));
-			textAlive_.erase(textAlive_.begin() + static_cast<std::ptrdiff_t>(i));
-		}
-	}
+    // ここでフラグが false のものを後ろから erase
+    for (size_t i = texts_.size(); i-- > 0;) {
+        if (i < textAlive_.size() && !textAlive_[i]) {
+            texts_.erase(texts_.begin() + static_cast<std::ptrdiff_t>(i));
+            textDefs_.erase(textDefs_.begin() + static_cast<std::ptrdiff_t>(i));
+            textAlive_.erase(textAlive_.begin() + static_cast<std::ptrdiff_t>(i));
+        }
+    }
 }
 
 // 全ての生存テキストオブジェクトを描画する。
 // textAlive_ が false のものは描画をスキップする。
 void TextManager::DrawAll() {
-	for (size_t i = 0; i < texts_.size(); ++i) {
-		if (i < textAlive_.size() && !textAlive_[i])
-			continue;
-		texts_[i]->Draw();
-	}
+    for (size_t i = 0; i < texts_.size(); ++i) {
+        if (i < textAlive_.size() && !textAlive_[i])
+            continue;
+        texts_[i]->Draw();
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -115,247 +115,268 @@ void TextManager::DrawAll() {
 // ・テキストオブジェクトの生成／編集／削除
 void TextManager::DrawImGui() {
 #ifdef USE_IMGUI
-	ImGui::Begin("TextManager");
+    ImGui::Begin("TextManager");
 
-	// レイアウトのロード/セーブ
-	if (ImGui::CollapsingHeader("Layout")) {
-		static char layoutPathBuf[256] = "Resources/Text/layout.json";
-		ImGui::InputText("Layout Path", layoutPathBuf, sizeof(layoutPathBuf));
-		if (ImGui::Button("Load Layout")) {
-			if (!LoadTextLayout(layoutPathBuf)) {
-				std::cerr << "Failed to load text layout: " << layoutPathBuf << std::endl;
-			}
-		}
-		ImGui::SameLine();
-		if (ImGui::Button("Save Layout")) {
-			if (!SaveTextLayout(layoutPathBuf)) {
-				std::cerr << "Failed to save text layout: " << layoutPathBuf << std::endl;
-			}
-		}
-	}
+    // レイアウトのロード/セーブ
+    if (ImGui::CollapsingHeader("Layout")) {
+        static char layoutPathBuf[256] = "Resources/Text/layout.json";
+        ImGui::InputText("Layout Path", layoutPathBuf, sizeof(layoutPathBuf));
+        if (ImGui::Button("Load Layout")) {
+            if (!LoadTextLayout(layoutPathBuf)) {
+                std::cerr << "Failed to load text layout: " << layoutPathBuf << std::endl;
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Save Layout")) {
+            if (!SaveTextLayout(layoutPathBuf)) {
+                std::cerr << "Failed to save text layout: " << layoutPathBuf << std::endl;
+            }
+        }
+    }
 
-	// フォントの追加UI（AddFont）
-	// プロジェクト／外部フォルダ／Windows フォルダからフォントを選択してロードし、
-	// addedFontNames_ に論理名を登録する。
-	if (ImGui::CollapsingHeader("Add Font")) {
-		static char fontNameBuf[64] = "";
-		static char fontFileBuf[128] = "msgothic.ttc";
-		static float fontSize = 32.0f;
-		static int sourceType = 2; // 0: Project, 1: External, 2: Windows
+    // フォントの追加UI（AddFont）
+    // プロジェクト／外部フォルダ／Windows フォルダからフォントを選択してロードし、
+    // addedFontNames_ に論理名を登録する。
+    if (ImGui::CollapsingHeader("Add Font")) {
+        static char fontNameBuf[64] = "";
+        static char fontFileBuf[128] = "msgothic.ttc";
+        static float fontSize = 32.0f;
+        static int sourceType = 2; // 0: Project, 1: External, 2: Windows
 
-		ImGui::InputText("Font Name", fontNameBuf, sizeof(fontNameBuf));
-		ImGui::InputText("Font File", fontFileBuf, sizeof(fontFileBuf));
-		ImGui::RadioButton("Project", &sourceType, 0);
-		ImGui::SameLine();
-		ImGui::RadioButton("External", &sourceType, 1);
-		ImGui::SameLine();
-		ImGui::RadioButton("Windows", &sourceType, 2);
-		ImGui::DragFloat("Font Size", &fontSize, 1.0f, 8.0f, 128.0f);
+        ImGui::InputText("Font Name", fontNameBuf, sizeof(fontNameBuf));
+        ImGui::InputText("Font File", fontFileBuf, sizeof(fontFileBuf));
+        ImGui::RadioButton("Project", &sourceType, 0);
+        ImGui::SameLine();
+        ImGui::RadioButton("External", &sourceType, 1);
+        ImGui::SameLine();
+        ImGui::RadioButton("Windows", &sourceType, 2);
+        ImGui::DragFloat("Font Size", &fontSize, 1.0f, 8.0f, 128.0f);
 
-		if (ImGui::Button("Load Font")) {
-			if (fontNameBuf[0] != '\0' && fontFileBuf[0] != '\0') {
-				Font* font = nullptr;
-				std::string fontName(fontNameBuf);
-				std::string fileName(fontFileBuf);
+        if (ImGui::Button("Load Font")) {
+            if (fontNameBuf[0] != '\0' && fontFileBuf[0] != '\0') {
+                Font* font = nullptr;
+                std::string fontName(fontNameBuf);
+                std::string fileName(fontFileBuf);
 
-				switch (sourceType) {
-				case 0:
-					font = LoadFontFromProject(fontName, fileName, fontSize);
-					break;
-				case 1:
-					font = LoadFontFromExternal(fontName, fileName, fontSize);
-					break;
-				case 2:
-					font = LoadFontFromWindows(fontName, fileName, fontSize);
-					break;
-				default:
-					break;
-				}
+                switch (sourceType) {
+                case 0:
+                    font = LoadFontFromProject(fontName, fileName, fontSize);
+                    break;
+                case 1:
+                    font = LoadFontFromExternal(fontName, fileName, fontSize);
+                    break;
+                case 2:
+                    font = LoadFontFromWindows(fontName, fileName, fontSize);
+                    break;
+                default:
+                    break;
+                }
 
-				if (!font) {
-					std::cerr << "Failed to load font via ImGui UI." << std::endl;
-				} else {
-					// AddFont グループに登録（BaseFont とは別）
-					addedFontNames_.push_back(fontName);
-				}
-			}
-		}
-	}
+                if (!font) {
+                    std::cerr << "Failed to load font via ImGui UI." << std::endl;
+                } else {
+                    // AddFont グループに登録（BaseFont とは別）
+                    addedFontNames_.push_back(fontName);
+                }
+            }
+        }
+    }
 
-	// 登録済みフォント一覧（BaseFont / AddFont / SizeFont を区別して表示）
-	if (ImGui::CollapsingHeader("Loaded Fonts")) {
-		ImGui::Text("BaseFont:");
-		for (const std::string& name : baseFontNames_) {
-			ImGui::BulletText("%s", name.c_str());
-		}
-		if (!addedFontNames_.empty()) {
-			ImGui::Separator();
-			ImGui::Text("AddFont:");
-			for (const std::string& name : addedFontNames_) {
-				ImGui::BulletText("%s", name.c_str());
-			}
-		}
-		if (!sizedFontNames_.empty()) {
-			ImGui::Separator();
-			ImGui::Text("SizeFont (generated, not selectable):");
-			for (const std::string& name : sizedFontNames_) {
-				ImGui::BulletText("%s", name.c_str());
-			}
-		}
-	}
+    // 登録済みフォント一覧（BaseFont / AddFont / SizeFont を区別して表示）
+    if (ImGui::CollapsingHeader("Loaded Fonts")) {
+        ImGui::Text("BaseFont:");
+        for (const std::string& name : baseFontNames_) {
+            ImGui::BulletText("%s", name.c_str());
+        }
+        if (!addedFontNames_.empty()) {
+            ImGui::Separator();
+            ImGui::Text("AddFont:");
+            for (const std::string& name : addedFontNames_) {
+                ImGui::BulletText("%s", name.c_str());
+            }
+        }
+        if (!sizedFontNames_.empty()) {
+            ImGui::Separator();
+            ImGui::Text("SizeFont (generated, not selectable):");
+            for (const std::string& name : sizedFontNames_) {
+                ImGui::BulletText("%s", name.c_str());
+            }
+        }
+    }
 
-	// テキストオブジェクトの管理UI（定義 + 実体）
-	// textDefs_ を編集しながら、対応する TextObject 実体(texts_)に即時反映する。
-	if (ImGui::CollapsingHeader("Text Objects")) {
-		if (ImGui::Button("Create New Text")) {
-			// 新規テキスト定義を追加し、対応する TextObject を生成
-			TextDefinition def{};
-			def.name = "Text" + std::to_string(textDefs_.size());
-			def.text = "New Text";
-			def.fontName = PresetFontNames::Best10;
-			def.fontSize = 32.0f;
-			def.position = Math::Vector2{100.0f, 100.0f};
-			def.color = Math::Vector4{1.0f, 1.0f, 1.0f, 1.0f};
-			def.scale = 1.0f;
-			textDefs_.push_back(def);
+    // テキストオブジェクトの管理UI（定義 + 実体）
+    // textDefs_ を編集しながら、対応する TextObject 実体(texts_)に即時反映する。
+    if (ImGui::CollapsingHeader("Text Objects")) {
+        if (ImGui::Button("Create New Text")) {
+            // 新規テキスト定義を追加し、対応する TextObject を生成
+            TextDefinition def{};
+            def.name = "Text" + std::to_string(textDefs_.size());
+            def.text = "New Text";
+            def.fontName = PresetFontNames::Best10;
+            def.fontSize = 32.0f;
+            def.position = Math::Vector2{100.0f, 100.0f};
+            def.color = Math::Vector4{1.0f, 1.0f, 1.0f, 1.0f};
+            def.scale = 1.0f;
+            def.horizontalAlign = 0;
+            def.verticalAlign = 0;
+            textDefs_.push_back(def);
 
-			Font* font = GetOrCreateFontSized(def.fontName, def.fontSize);
-			if (font) {
-				// フォントサイズ付き論理名で TextObject を生成
-				TextObject* obj = CreateText(def.fontName + "_" + std::to_string(static_cast<int>(def.fontSize)), def.text, def.position, def.color, def.scale);
-				if (obj) {
-					obj->SetFont(font);
-				}
-			}
-		}
+            Font* font = GetOrCreateFontSized(def.fontName, def.fontSize);
+            if (font) {
+                // フォントサイズ付き論理名で TextObject を生成
+                TextObject* obj = CreateText(def.fontName + "_" + std::to_string(static_cast<int>(def.fontSize)), def.text, def.position, def.color, def.scale);
+                if (obj) {
+                    obj->SetFont(font);
+                    obj->SetHorizontalAlign(def.horizontalAlign);
+                    obj->SetVerticalAlign(def.verticalAlign);
+                }
+            }
+        }
 
-		ImGui::Separator();
+        ImGui::Separator();
 
-		// textDefs_ と texts_ は同じインデックスで対応している前提
-		for (size_t index = 0; index < textDefs_.size() && index < texts_.size();) {
-			TextDefinition& def = textDefs_[index];
-			TextObject* textObj = texts_[index].get();
+        // textDefs_ と texts_ は同じインデックスで対応している前提
+        for (size_t index = 0; index < textDefs_.size() && index < texts_.size();) {
+            TextDefinition& def = textDefs_[index];
+            TextObject* textObj = texts_[index].get();
 
-			ImGui::PushID(static_cast<int>(index));
-			// ツリーラベル: 表示名 + 固定ID + index（ImGui の ID は ## 以降）
-			char treeLabel[128];
-			std::snprintf(treeLabel, sizeof(treeLabel), "TextObject [%s]##TextDef%zu", def.name.c_str(), index);
-			bool isOpen = ImGui::TreeNode(treeLabel);
-			ImGui::SameLine();
-			if (ImGui::Button("Delete")) {
-				// 論理削除: フラグを false にする
-				// 実際の erase は UpdateAll() の後ろから走査で行う。
-				if (index < textAlive_.size()) {
-					textAlive_[index] = false;
-				}
-				ImGui::PopID();
-				if (isOpen) {
-					ImGui::TreePop();
-				}
-				++index;
-				continue;
-			}
+            ImGui::PushID(static_cast<int>(index));
+            // ツリーラベル: 表示名 + 固定ID + index（ImGui の ID は ## 以降）
+            char treeLabel[128];
+            std::snprintf(treeLabel, sizeof(treeLabel), "TextObject [%s]##TextDef%zu", def.name.c_str(), index);
+            bool isOpen = ImGui::TreeNode(treeLabel);
+            ImGui::SameLine();
+            if (ImGui::Button("Delete")) {
+                // 論理削除: フラグを false にする
+                // 実際の erase は UpdateAll() の後ろから走査で行う。
+                if (index < textAlive_.size()) {
+                    textAlive_[index] = false;
+                }
+                ImGui::PopID();
+                if (isOpen) {
+                    ImGui::TreePop();
+                }
+                ++index;
+                continue;
+            }
 
-			if (isOpen) {
-				// name
-				char nameBuf[64];
-				std::snprintf(nameBuf, sizeof(nameBuf), "%s", def.name.c_str());
-				if (ImGui::InputText("Name", nameBuf, sizeof(nameBuf))) {
-					def.name = nameBuf;
-				}
+            if (isOpen) {
+                // name
+                char nameBuf[64];
+                std::snprintf(nameBuf, sizeof(nameBuf), "%s", def.name.c_str());
+                if (ImGui::InputText("Name", nameBuf, sizeof(nameBuf))) {
+                    def.name = nameBuf;
+                }
 
-				// text: use a local fixed buffer each frame, seeded from def.text
-				// ImGui の編集結果を TextObject に即時反映する。
-				{
-					char textBuf[1024];
-					std::size_t len = def.text.size();
-					if (len >= sizeof(textBuf)) {
-						len = sizeof(textBuf) - 1;
-					}
-					std::memcpy(textBuf, def.text.data(), len);
-					textBuf[len] = '\0';
-					if (ImGui::InputTextMultiline("Text", textBuf, sizeof(textBuf))) {
-						def.text = textBuf;
-						textObj->SetText(def.text);
-					}
-				}
+                // text: use a local fixed buffer each frame, seeded from def.text
+                // ImGui の編集結果を TextObject に即時反映する。
+                {
+                    char textBuf[1024];
+                    std::size_t len = def.text.size();
+                    if (len >= sizeof(textBuf)) {
+                        len = sizeof(textBuf) - 1;
+                    }
+                    std::memcpy(textBuf, def.text.data(), len);
+                    textBuf[len] = '\0';
+                    if (ImGui::InputTextMultiline("Text", textBuf, sizeof(textBuf))) {
+                        def.text = textBuf;
+                        textObj->SetText(def.text);
+                    }
+                }
 
-				// position
-				float pos[2] = {def.position.x, def.position.y};
-				if (ImGui::DragFloat2("Position", pos, 1.0f)) {
-					def.position.x = pos[0];
-					def.position.y = pos[1];
-					textObj->SetPosition(def.position);
-				}
+                // position
+                float pos[2] = {def.position.x, def.position.y};
+                if (ImGui::DragFloat2("Position", pos, 1.0f)) {
+                    def.position.x = pos[0];
+                    def.position.y = pos[1];
+                    textObj->SetPosition(def.position);
+                }
 
-				// color
-				float col[4] = {def.color.x, def.color.y, def.color.z, def.color.w};
-				if (ImGui::ColorEdit4("Color", col)) {
-					def.color = Math::Vector4{col[0], col[1], col[2], col[3]};
-					textObj->SetColor(def.color);
-				}
+                // color
+                float col[4] = {def.color.x, def.color.y, def.color.z, def.color.w};
+                if (ImGui::ColorEdit4("Color", col)) {
+                    def.color = Math::Vector4{col[0], col[1], col[2], col[3]};
+                    textObj->SetColor(def.color);
+                }
 
-				// scale（見た目のスケール調整）
-				float scale = def.scale;
-				if (ImGui::DragFloat("Scale", &scale, 0.01f, 0.1f, 10.0f)) {
-					def.scale = scale;
-					textObj->SetScale(def.scale);
-				}
+                // scale（見た目のスケール調整）
+                float scale = def.scale;
+                if (ImGui::DragFloat("Scale", &scale, 0.01f, 0.1f, 10.0f)) {
+                    def.scale = scale;
+                    textObj->SetScale(def.scale);
+                }
 
-				// BaseFont + AddFont から選択（SizeFont は対象外）
-				// selectableFontNames から選択した baseName と fontSize から
-				// GetOrCreateFontSized() を通して実フォントを取得する。
-				std::vector<const char*> selectableFontNames;
-				std::vector<std::string> selectableNamesStorage;
-				// BaseFont
-				for (const std::string& n : baseFontNames_) {
-					selectableNamesStorage.push_back(n);
-				}
-				// AddFont
-				for (const std::string& n : addedFontNames_) {
-					selectableNamesStorage.push_back(n);
-				}
-				for (std::string& s : selectableNamesStorage) {
-					selectableFontNames.push_back(s.c_str());
-				}
+                // 揃え設定
+                {
+                    static const char* hItems[] = { "Left", "Center", "Right" };
+                    int hAlign = def.horizontalAlign;
+                    if (ImGui::Combo("Horizontal Align", &hAlign, hItems, IM_ARRAYSIZE(hItems))) {
+                        def.horizontalAlign = hAlign;
+                        textObj->SetHorizontalAlign(def.horizontalAlign);
+                    }
 
-				int baseIndex = 0;
-				for (int i = 0; i < static_cast<int>(selectableNamesStorage.size()); ++i) {
-					if (def.fontName == selectableNamesStorage[i]) {
-						baseIndex = i;
-						break;
-					}
-				}
-				if (!selectableFontNames.empty()) {
-					if (ImGui::Combo("Base/Add Font", &baseIndex, selectableFontNames.data(), static_cast<int>(selectableFontNames.size()))) {
-						def.fontName = selectableNamesStorage[baseIndex];
-						Font* sizedFont = GetOrCreateFontSized(def.fontName, def.fontSize);
-						if (sizedFont) {
-							textObj->SetFont(sizedFont);
-						}
-					}
-				}
+                    static const char* vItems[] = { "Top", "Middle", "Bottom" };
+                    int vAlign = def.verticalAlign;
+                    if (ImGui::Combo("Vertical Align", &vAlign, vItems, IM_ARRAYSIZE(vItems))) {
+                        def.verticalAlign = vAlign;
+                        textObj->SetVerticalAlign(def.verticalAlign);
+                    }
+                }
 
-				// フォントサイズ（実サイズ）
-				// baseName とサイズから SizeFont を生成し、そのフォントを TextObject に設定する。
-				float fontSize = def.fontSize;
-				if (ImGui::DragFloat("Font Size", &fontSize, 1.0f, 8.0f, 128.0f)) {
-					def.fontSize = fontSize;
-					Font* sizedFont = GetOrCreateFontSized(def.fontName, def.fontSize);
-					if (sizedFont) {
-						textObj->SetFont(sizedFont);
-					}
-				}
+                // BaseFont + AddFont から選択（SizeFont は対象外）
+                // selectableFontNames から選択した baseName と fontSize から
+                // GetOrCreateFontSized() を通して実フォントを取得する。
+                std::vector<const char*> selectableFontNames;
+                std::vector<std::string> selectableNamesStorage;
+                // BaseFont
+                for (const std::string& n : baseFontNames_) {
+                    selectableNamesStorage.push_back(n);
+                }
+                // AddFont
+                for (const std::string& n : addedFontNames_) {
+                    selectableNamesStorage.push_back(n);
+                }
+                for (std::string& s : selectableNamesStorage) {
+                    selectableFontNames.push_back(s.c_str());
+                }
 
-				ImGui::TreePop();
-			}
+                int baseIndex = 0;
+                for (int i = 0; i < static_cast<int>(selectableNamesStorage.size()); ++i) {
+                    if (def.fontName == selectableNamesStorage[i]) {
+                        baseIndex = i;
+                        break;
+                    }
+                }
+                if (!selectableFontNames.empty()) {
+                    if (ImGui::Combo("Base/Add Font", &baseIndex, selectableFontNames.data(), static_cast<int>(selectableFontNames.size()))) {
+                        def.fontName = selectableNamesStorage[baseIndex];
+                        Font* sizedFont = GetOrCreateFontSized(def.fontName, def.fontSize);
+                        if (sizedFont) {
+                            textObj->SetFont(sizedFont);
+                        }
+                    }
+                }
 
-			ImGui::PopID();
-			++index;
-		}
-	}
+                // フォントサイズ（実サイズ）
+                // baseName とサイズから SizeFont を生成し、そのフォントを TextObject に設定する。
+                float fontSize = def.fontSize;
+                if (ImGui::DragFloat("Font Size", &fontSize, 1.0f, 8.0f, 128.0f)) {
+                    def.fontSize = fontSize;
+                    Font* sizedFont = GetOrCreateFontSized(def.fontName, def.fontSize);
+                    if (sizedFont) {
+                        textObj->SetFont(sizedFont);
+                    }
+                }
 
-	ImGui::End();
+                ImGui::TreePop();
+            }
+
+            ImGui::PopID();
+            ++index;
+        }
+    }
+
+    ImGui::End();
 #endif
 }
 
@@ -367,91 +388,91 @@ void TextManager::DrawImGui() {
 // - すでに同名のフォントが存在する場合はそれを再利用。
 // - 成功時は Font* を返し、失敗時は nullptr を返す。
 Font* TextManager::LoadFont(const std::string& name, const std::string& filePath, float size) {
-	std::unordered_map<std::string, std::unique_ptr<Font>>::iterator it = fonts_.find(name);
-	if (it != fonts_.end()) {
-		return it->second.get();
-	}
+    std::unordered_map<std::string, std::unique_ptr<Font>>::iterator it = fonts_.find(name);
+    if (it != fonts_.end()) {
+        return it->second.get();
+    }
 
-	std::unique_ptr<Font> font = std::make_unique<Font>();
-	std::wstring filePathW(filePath.begin(), filePath.end());
-	if (font->Initialize(filePathW, size)) {
-		Font* ptr = font.get();
-		fonts_[name] = std::move(font);
-		return ptr;
-	}
+    std::unique_ptr<Font> font = std::make_unique<Font>();
+    std::wstring filePathW(filePath.begin(), filePath.end());
+    if (font->Initialize(filePathW, size)) {
+        Font* ptr = font.get();
+        fonts_[name] = std::move(font);
+        return ptr;
+    }
 
-	std::cerr << "Failed to load font: " << filePath << std::endl;
-	return nullptr;
+    std::cerr << "Failed to load font: " << filePath << std::endl;
+    return nullptr;
 }
 
 // プロジェクト内フォントディレクトリからフォントを読み込む。
 Font* TextManager::LoadFontFromProject(const std::string& name, const std::string& fileName, float size) {
-	std::string path = projectFontDir_ + fileName;
-	return LoadFont(name, path, size);
+    std::string path = projectFontDir_ + fileName;
+    return LoadFont(name, path, size);
 }
 
 // 外部フォントディレクトリからフォントを読み込む。
 Font* TextManager::LoadFontFromExternal(const std::string& name, const std::string& fileName, float size) {
-	std::string path = externalFontDir_ + fileName;
-	return LoadFont(name, path, size);
+    std::string path = externalFontDir_ + fileName;
+    return LoadFont(name, path, size);
 }
 
 // Windows 標準フォントディレクトリからフォントを読み込む。
 // 非 Windows 環境ではダミー実装となる。
 Font* TextManager::LoadFontFromWindows(const std::string& name, const std::string& fileName, float size) {
 #ifdef _WIN32
-	std::string path = windowsFontDir_ + fileName;
-	return LoadFont(name, path, size);
+    std::string path = windowsFontDir_ + fileName;
+    return LoadFont(name, path, size);
 #else
-	(void)name;
-	(void)fileName;
-	(void)size;
-	std::cerr << "LoadFontFromWindows is only supported on Windows." << std::endl;
-	return nullptr;
+    (void)name;
+    (void)fileName;
+    (void)size;
+    std::cerr << "LoadFontFromWindows is only supported on Windows." << std::endl;
+    return nullptr;
 #endif
 }
 
 // 名前から Font インスタンスを取得するヘルパー。
 // 未ロードの場合は nullptr を返す。
 Font* TextManager::GetFont(const std::string& name) {
-	std::unordered_map<std::string, std::unique_ptr<Font>>::iterator it = fonts_.find(name);
-	if (it != fonts_.end()) {
-		return it->second.get();
-	}
-	return nullptr;
+    std::unordered_map<std::string, std::unique_ptr<Font>>::iterator it = fonts_.find(name);
+    if (it != fonts_.end()) {
+        return it->second.get();
+    }
+    return nullptr;
 }
 
 // BaseFont / AddFont とフォントサイズから、サイズ付きフォント(SizeFont)を取得もしくは生成する。
 // 論理名は「baseName_サイズ」（例: "Best10_32"）とし、すでに存在する場合は再利用する。
 Font* TextManager::GetOrCreateFontSized(const std::string& baseName, float fontSize) {
-	std::string sizedName = baseName + "_" + std::to_string(static_cast<int>(fontSize));
+    std::string sizedName = baseName + "_" + std::to_string(static_cast<int>(fontSize));
 
-	Font* existing = GetFont(sizedName);
-	if (existing) {
-		return existing;
-	}
+    Font* existing = GetFont(sizedName);
+    if (existing) {
+        return existing;
+    }
 
-	// BaseFont の場合は固定のファイル名にマッピング。
-	// AddFont からの baseName は、そのまま external フォントファイル名とみなす。
-	std::string fileName;
-	if (baseName == PresetFontNames::Best10) {
-		fileName = "BestTen-CRT.otf";
-	} else if (baseName == PresetFontNames::SoukouMincho) {
-		fileName = "SoukouMincho.ttf";
-	} else if (baseName == PresetFontNames::UtsukushiFONT) {
-		fileName = "UtsukushiFONT.otf";
-	} else if (baseName == PresetFontNames::YasashisaGothicBold) {
-		fileName = "YasashisaGothicBold-V2.otf";
-	} else {
-		// AddFont からの baseName は、そのまま external ファイル名とみなす
-		fileName = baseName;
-	}
+    // BaseFont の場合は固定のファイル名にマッピング。
+    // AddFont からの baseName は、そのまま external フォントファイル名とみなす。
+    std::string fileName;
+    if (baseName == PresetFontNames::Best10) {
+        fileName = "BestTen-CRT.otf";
+    } else if (baseName == PresetFontNames::SoukouMincho) {
+        fileName = "SoukouMincho.ttf";
+    } else if (baseName == PresetFontNames::UtsukushiFONT) {
+        fileName = "UtsukushiFONT.otf";
+    } else if (baseName == PresetFontNames::YasashisaGothicBold) {
+        fileName = "YasashisaGothicBold-V2.otf";
+    } else {
+        // AddFont からの baseName は、そのまま external ファイル名とみなす
+        fileName = baseName;
+    }
 
-	Font* sized = LoadFontFromExternal(sizedName, fileName, fontSize);
-	if (sized) {
-		sizedFontNames_.push_back(sizedName);
-	}
-	return sized;
+    Font* sized = LoadFontFromExternal(sizedName, fileName, fontSize);
+    if (sized) {
+        sizedFontNames_.push_back(sizedName);
+    }
+    return sized;
 }
 
 //----------------------------------------------------------------------------
@@ -462,36 +483,36 @@ Font* TextManager::GetOrCreateFontSized(const std::string& baseName, float fontS
 // - 指定フォント名から Font を取得できなければ nullptr を返す。
 // - 生成した TextObject は TextManager 内部の texts_ に所有させ、textAlive_ に true を追加する。
 TextObject* TextManager::CreateText(const std::string& fontName, const std::string& text, const Math::Vector2& pos, const Math::Vector4& color, float scale) {
-	Font* font = GetFont(fontName);
-	if (!font) {
-		std::cerr << "Font not found: " << fontName << std::endl;
-		return nullptr;
-	}
+    Font* font = GetFont(fontName);
+    if (!font) {
+        std::cerr << "Font not found: " << fontName << std::endl;
+        return nullptr;
+    }
 
-	std::unique_ptr<TextObject> textObj = std::make_unique<TextObject>();
-	textObj->Initialize();
-	textObj->SetFont(font);
-	textObj->SetText(text);
-	textObj->SetPosition(pos);
-	textObj->SetColor(color);
-	textObj->SetScale(scale);
+    std::unique_ptr<TextObject> textObj = std::make_unique<TextObject>();
+    textObj->Initialize();
+    textObj->SetFont(font);
+    textObj->SetText(text);
+    textObj->SetPosition(pos);
+    textObj->SetColor(color);
+    textObj->SetScale(scale);
 
-	TextObject* ptr = textObj.get();
-	texts_.push_back(std::move(textObj));
-	textAlive_.push_back(true); 
-	return ptr;
+    TextObject* ptr = textObj.get();
+    texts_.push_back(std::move(textObj));
+    textAlive_.push_back(true); 
+    return ptr;
 }
 
 // TextObject を削除予約する。
 // 実際の削除は UpdateAll() で行われるため、ここでは textAlive_ のフラグを false にするだけ。
 void TextManager::RemoveText(TextObject* text) {
-	auto it = std::find_if(texts_.begin(), texts_.end(), [text](const std::unique_ptr<TextObject>& ptr) { return ptr.get() == text; });
-	if (it != texts_.end()) {
-		size_t idx = static_cast<size_t>(std::distance(texts_.begin(), it));
-		if (idx < textAlive_.size()) {
-			textAlive_[idx] = false; // 削除予約
-		}
-	}
+    auto it = std::find_if(texts_.begin(), texts_.end(), [text](const std::unique_ptr<TextObject>& ptr) { return ptr.get() == text; });
+    if (it != texts_.end()) {
+        size_t idx = static_cast<size_t>(std::distance(texts_.begin(), it));
+        if (idx < textAlive_.size()) {
+            textAlive_[idx] = false; // 削除予約
+        }
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -502,106 +523,112 @@ void TextManager::RemoveText(TextObject* text) {
 // - 事前に DirectX のコマンドを一通り実行し、GPU の処理完了を待ってから破棄・再生成を行う。
 // - "texts" 配列から TextDefinition を構築し、それに対応する TextObject を CreateText で生成する。
 bool TextManager::LoadTextLayout(const std::string& filePath) {
-	// レイアウト差し替え前に一度 GPU 完了を待つ
-	{
-		auto* dx = TuboEngine::DirectXCommon::GetInstance();
-		dx->CommandExecution(); // 何もコマンドを積んでいなければ fence 待ちになるだけ
-	}
+    // レイアウト差し替え前に一度 GPU 完了を待つ
+    {
+        auto* dx = TuboEngine::DirectXCommon::GetInstance();
+        dx->CommandExecution(); // 何もコマンドを積んでいなければ fence 待ちになるだけ
+    }
 
-	std::ifstream ifs(filePath);
-	if (!ifs) {
-		return false;
-	}
+    std::ifstream ifs(filePath);
+    if (!ifs) {
+        return false;
+    }
 
-	json root;
-	try {
-		ifs >> root;
-	} catch (...) {
-		std::cerr << "Failed to parse text layout JSON: " << filePath << std::endl;
-		return false;
-	}
+    json root;
+    try {
+        ifs >> root;
+    } catch (...) {
+        std::cerr << "Failed to parse text layout JSON: " << filePath << std::endl;
+        return false;
+    }
 
-	if (!root.contains("texts") || !root["texts"].is_array()) {
-		return false;
-	}
+    if (!root.contains("texts") || !root["texts"].is_array()) {
+        return false;
+    }
 
-	// 既存の定義・実体をクリアしてから、新しいレイアウトを構築する。
-	textDefs_.clear();
-	texts_.clear();
-	textAlive_.clear();
+    // 既存の定義・実体をクリアしてから、新しいレイアウトを構築する。
+    textDefs_.clear();
+    texts_.clear();
+    textAlive_.clear();
 
-	// 以下は今の実装のまま
-	for (json& jt : root["texts"]) {
-		TextDefinition def{};
-		def.name = jt.value("name", "");
-		def.text = jt.value("text", "");
-		def.fontName = jt.value("font", PresetFontNames::Best10);
-		def.fontSize = jt.value("fontSize", 32.0f);
-		std::vector<float> posArr = jt.value("position", std::vector<float>{0.0f, 0.0f});
-		std::vector<float> colArr = jt.value("color", std::vector<float>{1.0f, 1.0f, 1.0f, 1.0f});
-		def.scale = jt.value("scale", 1.0f);
+    // 以下は今の実装のまま
+    for (json& jt : root["texts"]) {
+        TextDefinition def{};
+        def.name = jt.value("name", "");
+        def.text = jt.value("text", "");
+        def.fontName = jt.value("font", PresetFontNames::Best10);
+        def.fontSize = jt.value("fontSize", 32.0f);
+        std::vector<float> posArr = jt.value("position", std::vector<float>{0.0f, 0.0f});
+        std::vector<float> colArr = jt.value("color", std::vector<float>{1.0f, 1.0f, 1.0f, 1.0f});
+        def.scale = jt.value("scale", 1.0f);
+        def.horizontalAlign = jt.value("horizontalAlign", 0);
+        def.verticalAlign   = jt.value("verticalAlign", 0);
 
-		if (posArr.size() >= 2) {
-			def.position = Math::Vector2{posArr[0], posArr[1]};
-		}
-		if (colArr.size() >= 4) {
-			def.color = Math::Vector4{colArr[0], colArr[1], colArr[2], colArr[3]};
-		}
+        if (posArr.size() >= 2) {
+            def.position = Math::Vector2{posArr[0], posArr[1]};
+        }
+        if (colArr.size() >= 4) {
+            def.color = Math::Vector4{colArr[0], colArr[1], colArr[2], colArr[3]};
+        }
 
-		textDefs_.push_back(def);
-	}
+        textDefs_.push_back(def);
+    }
 
-	// 読み込んだ定義から TextObject 実体を生成し、フォントを設定する。
-	for (TextDefinition& def : textDefs_) {
-		Font* font = GetOrCreateFontSized(def.fontName, def.fontSize);
-		if (font) {
-			TextObject* obj = CreateText(def.fontName + "_" + std::to_string(static_cast<int>(def.fontSize)), def.text, def.position, def.color, def.scale);
-			if (obj) {
-				obj->SetFont(font);
-			}
-		}
-	}
+    // 読み込んだ定義から TextObject 実体を生成し、フォントを設定する。
+    for (TextDefinition& def : textDefs_) {
+        Font* font = GetOrCreateFontSized(def.fontName, def.fontSize);
+        if (font) {
+            TextObject* obj = CreateText(def.fontName + "_" + std::to_string(static_cast<int>(def.fontSize)), def.text, def.position, def.color, def.scale);
+            if (obj) {
+                obj->SetFont(font);
+                obj->SetHorizontalAlign(def.horizontalAlign);
+                obj->SetVerticalAlign(def.verticalAlign);
+            }
+        }
+    }
 
-	return true;
+    return true;
 }
 
 // 現在の textDefs_ を JSON 形式でファイルに書き出す。
 // - "texts" 配列に各 TextDefinition を保存。
 // - 必要であれば出力先ディレクトリを自動生成する。
 bool TextManager::SaveTextLayout(const std::string& filePath) const {
-	json root;
-	root["texts"] = json::array();
+    json root;
+    root["texts"] = json::array();
 
-	for (const TextDefinition& def : textDefs_) {
-		json jt;
-		jt["name"] = def.name;
-		jt["text"] = def.text;
-		jt["font"] = def.fontName;
-		jt["fontSize"] = def.fontSize;
-		jt["position"] = {def.position.x, def.position.y};
-		jt["color"] = {def.color.x, def.color.y, def.color.z, def.color.w};
-		jt["scale"] = def.scale;
-		root["texts"].push_back(jt);
-	}
+    for (const TextDefinition& def : textDefs_) {
+        json jt;
+        jt["name"] = def.name;
+        jt["text"] = def.text;
+        jt["font"] = def.fontName;
+        jt["fontSize"] = def.fontSize;
+        jt["position"] = {def.position.x, def.position.y};
+        jt["color"] = {def.color.x, def.color.y, def.color.z, def.color.w};
+        jt["scale"] = def.scale;
+        jt["horizontalAlign"] = def.horizontalAlign;
+        jt["verticalAlign"]   = def.verticalAlign;
+        root["texts"].push_back(jt);
+    }
 
-	// 親ディレクトリが無ければ作成
-	try {
-		std::filesystem::path path(filePath);
-		if (path.has_parent_path()) {
-			std::filesystem::create_directories(path.parent_path());
-		}
-	} catch (const std::exception& e) {
-		std::cerr << "Failed to create directories for layout: " << e.what() << std::endl;
-		return false;
-	}
+    // 親ディレクトリが無ければ作成
+    try {
+        std::filesystem::path path(filePath);
+        if (path.has_parent_path()) {
+            std::filesystem::create_directories(path.parent_path());
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to create directories for layout: " << e.what() << std::endl;
+        return false;
+    }
 
-	std::ofstream ofs(filePath);
-	if (!ofs) {
-		std::cerr << "Failed to open layout file for writing: " << filePath << std::endl;
-		return false;
-	}
-	ofs << root.dump(2);
-	return true;
+    std::ofstream ofs(filePath);
+    if (!ofs) {
+        std::cerr << "Failed to open layout file for writing: " << filePath << std::endl;
+        return false;
+    }
+    ofs << root.dump(2);
+    return true;
 }
 
 } // namespace TuboEngine

--- a/project/engine/graphic/2d/TextManager.h
+++ b/project/engine/graphic/2d/TextManager.h
@@ -38,6 +38,11 @@ public:
         Math::Vector2 position{0.0f, 0.0f};
         Math::Vector4 color{1.0f, 1.0f, 1.0f, 1.0f};
         float       scale = 1.0f;     // 見た目のスケール
+        // 揃え/アンカー情報
+        // 0: Left   1: Center   2: Right
+        int         horizontalAlign = 0;
+        // 0: Top    1: Middle   2: Bottom
+        int         verticalAlign   = 0;
     };
 
     // フォント管理

--- a/project/engine/graphic/2d/TextObject.cpp
+++ b/project/engine/graphic/2d/TextObject.cpp
@@ -119,6 +119,64 @@ void TextObject::Update() {
     float cursorX = 0.0f;
     float cursorY = 0.0f;
 
+    // まずはテキスト全体のサイズを計算
+    float totalWidth = 0.0f;
+    float totalHeight = 0.0f;
+    {
+        float lineWidth = 0.0f;
+        float maxLineWidth = 0.0f;
+        float height = font_->GetLineHeight();
+        for (char32_t c : text_) {
+            if (c == U'\n') {
+                if (lineWidth > maxLineWidth) { maxLineWidth = lineWidth; }
+                lineWidth = 0.0f;
+                height += font_->GetLineHeight();
+                continue;
+            }
+            const Font::Glyph* glyph = font_->GetGlyph(c);
+            if (!glyph) { continue; }
+            lineWidth += glyph->advanceX;
+        }
+        if (lineWidth > maxLineWidth) { maxLineWidth = lineWidth; }
+        totalWidth = maxLineWidth * scale_;
+        totalHeight = height * scale_;
+    }
+
+    // 揃えに応じた原点オフセット
+    float offsetX = 0.0f;
+    float offsetY = 0.0f;
+
+    // 横方向
+    switch (horizontalAlign_) {
+    case 1: // Center
+        offsetX = -totalWidth * 0.5f;
+        break;
+    case 2: // Right
+        offsetX = -totalWidth;
+        break;
+    case 0: // Left
+    default:
+        offsetX = 0.0f;
+        break;
+    }
+
+    // 縦方向
+    switch (verticalAlign_) {
+    case 1: // Middle
+        offsetY = -totalHeight * 0.5f;
+        break;
+    case 2: // Bottom
+        offsetY = -totalHeight;
+        break;
+    case 0: // Top
+    default:
+        offsetY = 0.0f;
+        break;
+    }
+
+    cursorX = 0.0f;
+    cursorY = 0.0f;
+
     for (char32_t c : text_) {
         if (currentCharacterCount_ >= maxCharacters_) break;
 
@@ -134,10 +192,10 @@ void TextObject::Update() {
         // 頂点データの生成
         uint32_t vIndex = currentCharacterCount_ * 4;
         
-        float left = cursorX + glyph->offsetX;
-        float right = left + glyph->width;
-        float top = cursorY + font_->GetBaseline() - glyph->offsetY;
-        float bottom = top + glyph->height;
+        float left = (cursorX + glyph->offsetX) * scale_ + offsetX;
+        float right = left + glyph->width * scale_;
+        float top = (cursorY + font_->GetBaseline() - glyph->offsetY) * scale_ + offsetY;
+        float bottom = top + glyph->height * scale_;
 
         // A (左下)
         vertexData_[vIndex + 0].position = { left, bottom, 0.0f, 1.0f };
@@ -165,7 +223,7 @@ void TextObject::Update() {
 
     // 行列の更新
     transform_.translate = { position_.x, position_.y, 0.0f };
-    transform_.scale = { scale_, scale_, 1.0f };
+    transform_.scale = { 1.0f, 1.0f, 1.0f }; // スケールは頂点に反映済み
 
     Matrix4x4 uvTransformMatrix = MakeAffineMatrix(uvTransform_.scale, uvTransform_.rotate, uvTransform_.translate);
     materialData_->uvTransform = uvTransformMatrix;

--- a/project/engine/graphic/2d/TextObject.h
+++ b/project/engine/graphic/2d/TextObject.h
@@ -26,6 +26,10 @@ public:
     void SetScale(float scale);
     void SetFont(Font* font);
 
+    // 揃え設定（0: Left/Top, 1: Center/Middle, 2: Right/Bottom）
+    void SetHorizontalAlign(int align) { horizontalAlign_ = align; dirty_ = true; }
+    void SetVerticalAlign(int align) { verticalAlign_ = align; dirty_ = true; }
+
     // Getter
     const Math::Vector2& GetPosition() const { return position_; }
     const Math::Vector4& GetColor() const { return color_; }
@@ -41,6 +45,10 @@ private:
     Math::Vector4 color_{1.0f, 1.0f, 1.0f, 1.0f};
     float scale_ = 1.0f;
     Font* font_ = nullptr;
+
+    // 揃えモード
+    int horizontalAlign_ = 0; // 0: Left, 1: Center, 2: Right
+    int verticalAlign_   = 0; // 0: Top, 1: Middle, 2: Bottom
 
     // 頂点バッファ / インデックスバッファ
     Microsoft::WRL::ComPtr<ID3D12Resource> vertexBuffer_;

--- a/project/imgui.ini
+++ b/project/imgui.ini
@@ -43,6 +43,7 @@ Collapsed=1
 [Window][Scene]
 Pos=6,68
 Size=95,213
+Collapsed=1
 
 [Window][DebugScene]
 Pos=805,223


### PR DESCRIPTION
TextDefinitionに揃え情報を追加し、layout.jsonの保存・読込、ImGui編集UI、TextObject描画処理を拡張しました。これによりテキストの左/中央/右・上/中央/下揃えが可能となり、レイアウト編集性が向上しました。また、スケール処理を頂点計算に統一し、transformのscaleは常に1.0となりました。